### PR TITLE
add centos-6.7

### DIFF
--- a/centos-6.7-i386/Makefile
+++ b/centos-6.7-i386/Makefile
@@ -1,0 +1,1 @@
+../common/Makefile

--- a/centos-6.7-i386/Vagrantfile
+++ b/centos-6.7-i386/Vagrantfile
@@ -1,0 +1,19 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "#{File.basename(Dir.pwd)}"
+
+  config.vm.provider :virtualbox do |v, override|
+   #override.vm.synced_folder ".", "/vagrant", disabled: true
+   #v.gui = true
+  end
+
+  config.vm.provider :vmware_workstation do |v, override|
+   #override.vm.synced_folder ".", "/vagrant", disabled: true
+   #v.gui = true
+  end
+end

--- a/centos-6.7-i386/ks.cfg
+++ b/centos-6.7-i386/ks.cfg
@@ -1,0 +1,108 @@
+install
+cdrom
+url --url http://ftp.jaist.ac.jp/pub/Linux/CentOS/6.7/os/i386/
+
+#unsupported_hardware
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp --hostname=vagrant-centos6
+rootpw vagrant
+services --disabled="sendmail,postfix" --enabled="sshd,ntpd,ntpdate"
+
+firewall --ssh
+selinux --disabled
+timezone Asia/Tokyo
+bootloader --location=mbr
+
+text
+skipx
+zerombr
+
+clearpart --all
+part / --fstype=ext4 --ondisk=sda --grow --label=root --size=1
+
+auth --useshadow --enablemd5
+firstboot --disabled
+reboot
+
+%packages --nobase --ignoremissing
+@Core
+# vmbuilder
+openssh
+openssh-clients
+openssh-server
+rpm
+yum
+curl
+dhclient
+passwd
+vim-minimal
+sudo
+# build kernel module
+kernel-devel
+gcc
+perl
+bzip2
+# bootstrap
+ntp
+ntpdate
+man
+sudo
+rsync
+git
+make
+vim-minimal
+screen
+nmap
+lsof
+strace
+tcpdump
+traceroute
+telnet
+ltrace
+bind-utils
+sysstat
+nc
+wireshark
+zip
+# shared folder
+nfs-utils
+#
+acpid
+%end
+
+%post
+# yum
+mkdir -p /etc/yum/vars
+echo 6.7 > /etc/yum/vars/releasever
+
+# udev
+rm -f /etc/udev/rules.d/70-persistent-net.rules
+ln -s /dev/null /etc/udev/rules.d/70-persistent-net.rules
+
+# account:vagrant
+groupadd vagrant
+useradd -g vagrant -d /home/vagrant -s /bin/bash -m vagrant
+echo umask 022 >> /home/vagrant/.bashrc
+echo vagrant:vagrant | chpasswd
+usermod -L root
+
+echo "vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+sed -i "s/^\(^Defaults\s*requiretty\).*/# \1/" /etc/sudoers
+
+# ttyS0
+sed -i "s,^ACTIVE_CONSOLES=.*,ACTIVE_CONSOLES=\"/dev/tty[1-6] /dev/ttyS0\"", /etc/sysconfig/init
+egrep -w "^ttyS0" /etc/securetty || { echo ttyS0 >> /etc/securetty; }
+
+# grub
+sed -i 's, rhgb quiet$,,' /boot/grub/grub.conf
+
+# ifcfg-eth0
+rm -f /etc/sysconfig/network-scripts/ifcfg-e*
+cat <<EOS > /etc/sysconfig/network-scripts/ifcfg-eth0
+DEVICE=eth0
+TYPE=Ethernet
+BOOTPROTO=dhcp
+ONBOOT=yes
+EOS
+%end

--- a/centos-6.7-i386/template.json
+++ b/centos-6.7-i386/template.json
@@ -1,0 +1,90 @@
+{
+  "variables": {
+      "vm_name": "centos-6.7-i386",
+      "iso_checksum": "ec1f887d9097ac704bb8d5624cda13af",
+      "iso_url": "http://ftp.jaist.ac.jp/pub/Linux/CentOS/6.7/isos/i386/CentOS-6.7-i386-netinstall.iso"
+  },
+  "builders": [
+    {
+      "type": "virtualbox-iso",
+      "vm_name": "_{{ user `vm_name` }}",
+      "iso_checksum_type": "md5",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_url": "{{ user `iso_url` }}",
+      "http_directory": ".",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter>"
+      ],
+      "headless": "true",
+      "guest_os_type": "RedHat",
+      "vboxmanage": [
+        [ "modifyvm", "{{.Name}}", "--memory", "1024" ],
+        [ "modifyvm", "{{.Name}}", "--cpus",   "1"    ]
+      ],
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "50000s",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p"
+    },
+    {
+      "type": "vmware-iso",
+      "vm_name": "_{{ user `vm_name` }}",
+      "iso_checksum_type": "md5",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_url": "{{ user `iso_url` }}",
+      "http_directory": ".",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter>"
+      ],
+      "headless": "true",
+      "guest_os_type": "rhel6-64",
+      "vmx_data": {
+        "memsize": "1024",
+        "numvcpus":   "1"
+      },
+      "tools_upload_flavor": "linux",
+      "vmdk_name": "box-disk1",
+      "disk_type_id": "0",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "50000s",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
+      "override": {
+        "virtualbox-iso": {
+          "scripts": [
+            "../common/scripts/setup.sh",
+            "../common/scripts/bootstrap.sh",
+            "../common/scripts/disable-selinux.sh",
+            "../common/scripts/sshd_config.sh",
+            "../common/scripts/vagrant.guest.account.sh",
+            "../common/scripts/virtualbox.guest.additions.sh",
+            "../common/scripts/teardown.sh"
+          ]
+        },
+        "vmware-iso": {
+          "scripts": [
+            "../common/scripts/setup.sh",
+            "../common/scripts/bootstrap.sh",
+            "../common/scripts/disable-selinux.sh",
+            "../common/scripts/sshd_config.sh",
+            "../common/scripts/vagrant.guest.account.sh",
+            "../common/scripts/vmware-tools.sh",
+            "../common/scripts/teardown.sh"
+          ]
+        }
+      }
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "output": "{{ user `vm_name` }}.{{.Provider}}.box"
+    }
+  ]
+}

--- a/centos-6.7-x86_64/Makefile
+++ b/centos-6.7-x86_64/Makefile
@@ -1,0 +1,1 @@
+../common/Makefile

--- a/centos-6.7-x86_64/Vagrantfile
+++ b/centos-6.7-x86_64/Vagrantfile
@@ -1,0 +1,19 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "#{File.basename(Dir.pwd)}"
+
+  config.vm.provider :virtualbox do |v, override|
+   #override.vm.synced_folder ".", "/vagrant", disabled: true
+   #v.gui = true
+  end
+
+  config.vm.provider :vmware_workstation do |v, override|
+   #override.vm.synced_folder ".", "/vagrant", disabled: true
+   #v.gui = true
+  end
+end

--- a/centos-6.7-x86_64/ks.cfg
+++ b/centos-6.7-x86_64/ks.cfg
@@ -1,0 +1,108 @@
+install
+cdrom
+url --url http://ftp.jaist.ac.jp/pub/Linux/CentOS/6.7/os/x86_64/
+
+#unsupported_hardware
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp --hostname=vagrant-centos6
+rootpw vagrant
+services --disabled="sendmail,postfix" --enabled="sshd,ntpd,ntpdate"
+
+firewall --ssh
+selinux --disabled
+timezone Asia/Tokyo
+bootloader --location=mbr
+
+text
+skipx
+zerombr
+
+clearpart --all
+part / --fstype=ext4 --ondisk=sda --grow --label=root --size=1
+
+auth --useshadow --enablemd5
+firstboot --disabled
+reboot
+
+%packages --nobase --ignoremissing
+@Core
+# vmbuilder
+openssh
+openssh-clients
+openssh-server
+rpm
+yum
+curl
+dhclient
+passwd
+vim-minimal
+sudo
+# build kernel module
+kernel-devel
+gcc
+perl
+bzip2
+# bootstrap
+ntp
+ntpdate
+man
+sudo
+rsync
+git
+make
+vim-minimal
+screen
+nmap
+lsof
+strace
+tcpdump
+traceroute
+telnet
+ltrace
+bind-utils
+sysstat
+nc
+wireshark
+zip
+# shared folder
+nfs-utils
+#
+acpid
+%end
+
+%post
+# yum
+mkdir -p /etc/yum/vars
+echo 6.7 > /etc/yum/vars/releasever
+
+# udev
+rm -f /etc/udev/rules.d/70-persistent-net.rules
+ln -s /dev/null /etc/udev/rules.d/70-persistent-net.rules
+
+# account:vagrant
+groupadd vagrant
+useradd -g vagrant -d /home/vagrant -s /bin/bash -m vagrant
+echo umask 022 >> /home/vagrant/.bashrc
+echo vagrant:vagrant | chpasswd
+usermod -L root
+
+echo "vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+sed -i "s/^\(^Defaults\s*requiretty\).*/# \1/" /etc/sudoers
+
+# ttyS0
+sed -i "s,^ACTIVE_CONSOLES=.*,ACTIVE_CONSOLES=\"/dev/tty[1-6] /dev/ttyS0\"", /etc/sysconfig/init
+egrep -w "^ttyS0" /etc/securetty || { echo ttyS0 >> /etc/securetty; }
+
+# grub
+sed -i 's, rhgb quiet$,,' /boot/grub/grub.conf
+
+# ifcfg-eth0
+rm -f /etc/sysconfig/network-scripts/ifcfg-e*
+cat <<EOS > /etc/sysconfig/network-scripts/ifcfg-eth0
+DEVICE=eth0
+TYPE=Ethernet
+BOOTPROTO=dhcp
+ONBOOT=yes
+EOS
+%end

--- a/centos-6.7-x86_64/template.json
+++ b/centos-6.7-x86_64/template.json
@@ -1,0 +1,90 @@
+{
+  "variables": {
+      "vm_name": "centos-6.7-x86_64",
+      "iso_checksum": "171ce654ec06040d096daf75934ca8ca",
+      "iso_url": "http://ftp.jaist.ac.jp/pub/Linux/CentOS/6.7/isos/x86_64/CentOS-6.7-x86_64-netinstall.iso"
+  },
+  "builders": [
+    {
+      "type": "virtualbox-iso",
+      "vm_name": "_{{ user `vm_name` }}",
+      "iso_checksum_type": "md5",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_url": "{{ user `iso_url` }}",
+      "http_directory": ".",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter>"
+      ],
+      "headless": "true",
+      "guest_os_type": "RedHat_64",
+      "vboxmanage": [
+        [ "modifyvm", "{{.Name}}", "--memory", "1024" ],
+        [ "modifyvm", "{{.Name}}", "--cpus",   "1"    ]
+      ],
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "50000s",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p"
+    },
+    {
+      "type": "vmware-iso",
+      "vm_name": "_{{ user `vm_name` }}",
+      "iso_checksum_type": "md5",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_url": "{{ user `iso_url` }}",
+      "http_directory": ".",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter>"
+      ],
+      "headless": "true",
+      "guest_os_type": "rhel6-64",
+      "vmx_data": {
+        "memsize": "1024",
+        "numvcpus":   "1"
+      },
+      "tools_upload_flavor": "linux",
+      "vmdk_name": "box-disk1",
+      "disk_type_id": "0",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "50000s",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
+      "override": {
+        "virtualbox-iso": {
+          "scripts": [
+            "../common/scripts/setup.sh",
+            "../common/scripts/bootstrap.sh",
+            "../common/scripts/disable-selinux.sh",
+            "../common/scripts/sshd_config.sh",
+            "../common/scripts/vagrant.guest.account.sh",
+            "../common/scripts/virtualbox.guest.additions.sh",
+            "../common/scripts/teardown.sh"
+          ]
+        },
+        "vmware-iso": {
+          "scripts": [
+            "../common/scripts/setup.sh",
+            "../common/scripts/bootstrap.sh",
+            "../common/scripts/disable-selinux.sh",
+            "../common/scripts/sshd_config.sh",
+            "../common/scripts/vagrant.guest.account.sh",
+            "../common/scripts/vmware-tools.sh",
+            "../common/scripts/teardown.sh"
+          ]
+        }
+      }
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "output": "{{ user `vm_name` }}.{{.Provider}}.box"
+    }
+  ]
+}

--- a/common/scripts/setup.sh
+++ b/common/scripts/setup.sh
@@ -15,7 +15,7 @@ majorver=${releasever%%.*}
 baseurl=http://vault.centos.org
 case "${releasever}" in
   # latest version
-  5.11 | 6.6 | 7.1.1503 )
+  5.11 | 6.7 | 7.1.1503 )
     baseurl=http://ftp.jaist.ac.jp/pub/Linux/CentOS
     ;;
 esac


### PR DESCRIPTION
ログは以下の通り(一部は削除してあります)
#### centos-6.7-x86_64

```
## make build

==> virtualbox-iso: Exporting virtual machine...
    virtualbox-iso: Executing: export _centos-6.7-x86_64 --output output-virtualbox-iso/_centos-6.7-x86_64.ovf
==> virtualbox-iso: Unregistering and deleting virtual machine...
==> virtualbox-iso: Running post-processor: vagrant
==> virtualbox-iso (vagrant): Creating Vagrant box for 'virtualbox' provider
    virtualbox-iso (vagrant): Copying from artifact: output-virtualbox-iso/_centos-6.7-x86_64-disk1.vmdk
    virtualbox-iso (vagrant): Copying from artifact: output-virtualbox-iso/_centos-6.7-x86_64.ovf
    virtualbox-iso (vagrant): Renaming the OVF to box.ovf...
    virtualbox-iso (vagrant): Compressing: Vagrantfile
    virtualbox-iso (vagrant): Compressing: _centos-6.7-x86_64-disk1.vmdk
    virtualbox-iso (vagrant): Compressing: box.ovf
    virtualbox-iso (vagrant): Compressing: metadata.json
Build 'virtualbox-iso' finished.

==> Builds finished. The artifacts of successful builds are:
--> virtualbox-iso: 'virtualbox' provider box: centos-6.7-x86_64.virtualbox.box

real    21m56.332s
user    0m39.037s
sys 0m10.264s
touch build-stamp


## make test

==> box: Adding box 'centos-6.7-x86_64' (v0) for provider:
==> box: Successfully added box 'centos-6.7-x86_64' (v0) for 'virtualbox'!

real    0m7.473s
user    0m5.055s
sys 0m1.382s
time vagrant up --provider virtualbox
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'centos-6.7-x86_64'...
==> default: Matching MAC address for NAT networking...
==> default: Setting the name of the VM: centos-67-x86_64_default_1439803365542_84
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
==> default: Forwarding ports...
    default: 22 => 2222 (adapter 1)
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: Warning: Connection timeout. Retrying...
    default:
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default:
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if its present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
GuestAdditions 4.3.30 running --- OK.
==> default: Checking for guest additions in VM...
==> default: Mounting shared folders...

real    0m41.479s
user    0m4.881s
sys 0m2.232s
time vagrant ssh -c hostname
vagrant-centos6
Connection to 127.0.0.1 closed.

real    0m3.347s
user    0m2.012s
sys 0m0.453s

Removing box 'centos-6.7-x86_64' (v0) with provider 'virtualbox'...

real    0m2.629s
user    0m1.921s
sys 0m0.289s
time vagrant destroy -f
==> default: Forcing shutdown of VM...
==> default: Destroying VM and associated drives...

real    0m4.974s
user    0m2.386s
sys 0m0.574s
touch test-stamp
```
#### centos-6.7-i386

```
## make build

==> virtualbox-iso: Exporting virtual machine...
    virtualbox-iso: Executing: export _centos-6.7-i386 --output output-virtualbox-iso/_centos-6.7-i386.ovf
==> virtualbox-iso: Unregistering and deleting virtual machine...
==> virtualbox-iso: Running post-processor: vagrant
==> virtualbox-iso (vagrant): Creating Vagrant box for 'virtualbox' provider
    virtualbox-iso (vagrant): Copying from artifact: output-virtualbox-iso/_centos-6.7-i386-disk1.vmdk
    virtualbox-iso (vagrant): Copying from artifact: output-virtualbox-iso/_centos-6.7-i386.ovf
    virtualbox-iso (vagrant): Renaming the OVF to box.ovf...
    virtualbox-iso (vagrant): Compressing: Vagrantfile
    virtualbox-iso (vagrant): Compressing: _centos-6.7-i386-disk1.vmdk
    virtualbox-iso (vagrant): Compressing: box.ovf
    virtualbox-iso (vagrant): Compressing: metadata.json
Build 'virtualbox-iso' finished.

==> Builds finished. The artifacts of successful builds are:
--> virtualbox-iso: 'virtualbox' provider box: centos-6.7-i386.virtualbox.box

real    25m6.308s
user    0m33.006s
sys 0m12.828s
touch build-stamp


## make test

==> box: Adding box 'centos-6.7-i386' (v0) for provider:
==> box: Successfully added box 'centos-6.7-i386' (v0) for 'virtualbox'!

real    0m8.009s
user    0m5.307s
sys 0m1.545s
time vagrant up --provider virtualbox
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'centos-6.7-i386'...
==> default: Matching MAC address for NAT networking...
==> default: Setting the name of the VM: centos-67-i386_default_1439804043858_39467
==> default: Fixed port collision for 22 => 2222. Now on port 2200.
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
==> default: Forwarding ports...
    default: 22 => 2200 (adapter 1)
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2200
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: Warning: Connection timeout. Retrying...
    default: Warning: Remote connection disconnect. Retrying...
    default:
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default:
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if its present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
GuestAdditions 4.3.30 running --- OK.
==> default: Checking for guest additions in VM...
==> default: Mounting shared folders...

real    0m39.559s
user    0m5.957s
sys 0m2.965s
time vagrant ssh -c hostname
vagrant-centos6
Connection to 127.0.0.1 closed.

real    0m2.978s
user    0m1.884s
sys 0m0.416s

Removing box 'centos-6.7-i386' (v0) with provider 'virtualbox'...

real    0m2.553s
user    0m1.838s
sys 0m0.302s
time vagrant destroy -f
==> default: Forcing shutdown of VM...
==> default: Destroying VM and associated drives...

real    0m4.685s
user    0m2.238s
sys 0m0.586s
touch test-stamp
```
