### PR TITLE
fixed v7.1.1503 and added v7.2.1511

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Current Boxes
 
 64-bit boxes:
 
++ [deepakprabhakara/centos-7](https://vagrantcloud.com/deepakprabhakara/centos-7)
 + [hansode/centos-7.1.1503-x86_64](https://vagrantcloud.com/hansode/centos-7.1.1503-x86_64)
 + [hansode/centos-7.0.1406-x86_64](https://vagrantcloud.com/hansode/centos-7.0.1406-x86_64)
 + [hansode/centos-6.6-x86_64](https://vagrantcloud.com/hansode/centos-6.6-x86_64)

--- a/centos-7.1.1503-x86_64/ks.cfg
+++ b/centos-7.1.1503-x86_64/ks.cfg
@@ -1,7 +1,6 @@
 install
 cdrom
-url --url http://mirror.centos.org/centos-7/7.1.1503/os/x86_64/
-
+url --url http://vault.centos.org/7.1.1503/os/x86_64/
 
 unsupported_hardware
 lang en_US.UTF-8

--- a/centos-7.1.1503-x86_64/template.json
+++ b/centos-7.1.1503-x86_64/template.json
@@ -2,7 +2,7 @@
   "variables": {
       "vm_name": "centos-7.1.1503-x86_64",
       "iso_checksum": "d07ab3e615c66a8b2e9a50f4852e6a77",
-      "iso_url": "http://ftp.riken.jp/Linux/centos/7.1.1503/isos/x86_64/CentOS-7-x86_64-Minimal-1503-01.iso"
+      "iso_url": "http://mirror.nsc.liu.se/centos-store/7.1.1503/isos/x86_64/CentOS-7-x86_64-Minimal-1503-01.iso"
   },
   "builders": [
     {

--- a/centos-7.2.1511-x86_64/Makefile
+++ b/centos-7.2.1511-x86_64/Makefile
@@ -1,0 +1,1 @@
+../common/Makefile

--- a/centos-7.2.1511-x86_64/Vagrantfile
+++ b/centos-7.2.1511-x86_64/Vagrantfile
@@ -1,0 +1,19 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "#{File.basename(Dir.pwd)}"
+
+  config.vm.provider :virtualbox do |v, override|
+   #override.vm.synced_folder ".", "/vagrant", disabled: true
+   #v.gui = true
+  end
+
+  config.vm.provider :vmware_workstation do |v, override|
+   #override.vm.synced_folder ".", "/vagrant", disabled: true
+   #v.gui = true
+  end
+end

--- a/centos-7.2.1511-x86_64/ks.cfg
+++ b/centos-7.2.1511-x86_64/ks.cfg
@@ -1,0 +1,111 @@
+install
+cdrom
+url --url http://mirror.centos.org/centos-7/7.2.1511/os/x86_64/
+
+
+unsupported_hardware
+lang en_US.UTF-8
+keyboard us
+network --bootproto=dhcp --hostname=vagrant-centos7
+rootpw vagrant
+services --disabled="sendmail,postfix" --enabled="sshd,ntpd,ntpdate"
+
+firewall --ssh
+selinux --disabled
+timezone Asia/Tokyo
+bootloader --location=mbr
+
+text
+skipx
+zerombr
+
+clearpart --all
+part / --fstype=ext4 --ondisk=sda --grow --label=root
+
+auth --useshadow --enablemd5
+firstboot --disabled
+reboot
+
+%packages --nobase --ignoremissing
+@Core
+# vmbuilder
+openssh
+openssh-clients
+openssh-server
+rpm
+yum
+curl
+dhclient
+passwd
+vim-minimal
+sudo
+# build kernel module
+kernel-devel
+gcc
+perl
+bzip2
+# bootstrap
+ntp
+ntpdate
+man
+sudo
+rsync
+git
+make
+vim-minimal
+screen
+nmap
+lsof
+strace
+tcpdump
+traceroute
+telnet
+ltrace
+bind-utils
+sysstat
+nc
+wireshark
+zip
+# shared folder
+nfs-utils
+#
+acpid
+%end
+
+%post
+# yum
+mkdir -p /etc/yum/vars
+echo 7.2.1511 > /etc/yum/vars/releasever
+
+# udev
+rm -f /etc/udev/rules.d/70-persistent-net.rules
+ln -s /dev/null /etc/udev/rules.d/70-persistent-net.rules
+
+# account:vagrant
+groupadd vagrant
+useradd -g vagrant -d /home/vagrant -s /bin/bash -m vagrant
+echo umask 022 >> /home/vagrant/.bashrc
+echo vagrant:vagrant | chpasswd
+usermod -L root
+
+echo "vagrant ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+sed -i "s/^\(^Defaults\s*requiretty\).*/# \1/" /etc/sudoers
+
+# ttyS0
+ln -s /usr/lib/systemd/system/getty@.service /etc/systemd/system/getty.target.wants/getty@ttyS0.service
+egrep -w "^ttyS0" /etc/securetty || { echo ttyS0 >> /etc/securetty; }
+
+# grub2
+sed -i 's/^GRUB_CMDLINE_LINUX=.*/GRUB_CMDLINE_LINUX="crashkernel=auto vconsole.font=latarcyrheb-sun16 vconsole.keymap=us crashkernel=auto net.ifnames=0 biosdevname=0"/' /etc/default/grub
+grub2-mkconfig -o /boot/grub2/grub.cfg
+
+# ifcfg-eth0
+rm -f /etc/sysconfig/network-scripts/ifcfg-e*
+rm -f /etc/sysconfig/network-scripts/ifcfg-p*p*
+cat <<EOS > /etc/sysconfig/network-scripts/ifcfg-eth0
+DEVICE=eth0
+TYPE=Ethernet
+BOOTPROTO=dhcp
+ONBOOT=yes
+EOS
+%end

--- a/centos-7.2.1511-x86_64/template.json
+++ b/centos-7.2.1511-x86_64/template.json
@@ -1,0 +1,88 @@
+{
+  "variables": {
+      "vm_name": "centos-7.2.1511-x86_64",
+      "iso_checksum": "88c0437f0a14c6e2c94426df9d43cd67",
+      "iso_url": "http://ftp.riken.jp/Linux/centos/7.2.1511/isos/x86_64/CentOS-7-x86_64-Minimal-1511.iso"
+  },
+  "builders": [
+    {
+      "type": "virtualbox-iso",
+      "vm_name": "_{{ user `vm_name` }}",
+      "iso_checksum_type": "md5",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_url": "{{ user `iso_url` }}",
+      "http_directory": ".",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter>"
+      ],
+      "headless": "true",
+      "guest_os_type": "RedHat_64",
+      "vboxmanage": [
+        [ "modifyvm", "{{.Name}}", "--memory", "1024" ],
+        [ "modifyvm", "{{.Name}}", "--cpus",   "1"    ]
+      ],
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "50000s",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p"
+    },
+    {
+      "type": "vmware-iso",
+      "vm_name": "_{{ user `vm_name` }}",
+      "iso_checksum_type": "md5",
+      "iso_checksum": "{{ user `iso_checksum` }}",
+      "iso_url": "{{ user `iso_url` }}",
+      "http_directory": ".",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter>"
+      ],
+      "headless": "true",
+      "guest_os_type": "rhel7-64",
+      "vmx_data": {
+        "memsize": "1024",
+        "numvcpus":   "1"
+      },
+      "vmdk_name": "box-disk1",
+      "disk_type_id": "0",
+      "ssh_password": "vagrant",
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "50000s",
+      "shutdown_command": "echo 'vagrant' | sudo -S /sbin/halt -h -p"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'",
+      "override": {
+        "virtualbox-iso": {
+          "scripts": [
+            "../common/scripts/setup.sh",
+            "../common/scripts/bootstrap.sh",
+            "../common/scripts/disable-selinux.sh",
+            "../common/scripts/sshd_config.sh",
+            "../common/scripts/vagrant.guest.account.sh",
+            "../common/scripts/virtualbox.guest.additions.sh",
+            "../common/scripts/teardown.sh"
+          ]
+        },
+        "vmware-iso": {
+          "scripts": [
+            "../common/scripts/setup.sh",
+            "../common/scripts/bootstrap.sh",
+            "../common/scripts/disable-selinux.sh",
+            "../common/scripts/sshd_config.sh",
+            "../common/scripts/vagrant.guest.account.sh",
+            "../common/scripts/teardown.sh"
+          ]
+        }
+      }
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "output": "{{ user `vm_name` }}.{{.Provider}}.box"
+    }
+]
+}

--- a/common/scripts/setup.sh
+++ b/common/scripts/setup.sh
@@ -15,7 +15,7 @@ majorver=${releasever%%.*}
 baseurl=http://vault.centos.org
 case "${releasever}" in
   # latest version
-  5.11 | 6.7 | 7.1.1503 )
+  5.11 | 6.7 | 7.2.1511 )
     baseurl=http://ftp.jaist.ac.jp/pub/Linux/CentOS
     ;;
 esac


### PR DESCRIPTION
CentOS v7.2.1511 has been released, which broke the links being used for v7.1.1503. I have switched the links to working ones and also added a template for v7.2.1511.

Could you please merge (if all ok) and then make a new build (especially for v7.1.1503) and push to Atlas.

Regards.
Deepak.
